### PR TITLE
docs: add Sahara and Pharos contribution records

### DIFF
--- a/Pharos.md
+++ b/Pharos.md
@@ -1,0 +1,29 @@
+# POSTHUMAN contributions to Pharos
+
+POSTHUMAN participated in the Pharos Atlantic testnet through infrastructure
+operation, monitoring, and public operator documentation. This is a
+historical testnet record; it does not claim an active validator or public
+endpoint.
+
+## Technical contributions
+
+- Deployed and synchronized a Docker-based Pharos Atlantic testnet full node
+  in April 2026.
+- Added local health monitoring and documented key-backup, RPC verification,
+  peer checks, update, and troubleshooting procedures.
+- Published a reusable installation guide covering the official network
+  configuration, Docker deployment, key custody, and validator application
+  flow.
+
+## Public documentation
+
+- [Pharos Atlantic testnet installation guide](https://github.com/Validator-POSTHUMAN/posthuman-source-data/blob/main/pharos-testnet/installation-guide.md)
+
+## Official Pharos resources
+
+- Website: https://pharosnetwork.xyz/
+- Documentation: https://docs.pharosnetwork.xyz/
+- GitHub: https://github.com/PharosNetwork
+
+No upstream Pharos pull request, formal partnership, endorsement, or
+currently active POSTHUMAN service is claimed on this page.

--- a/Sahara.md
+++ b/Sahara.md
@@ -1,0 +1,28 @@
+# POSTHUMAN contributions to Sahara AI
+
+POSTHUMAN participated in the Sahara AI testnet through infrastructure
+testing and public operator documentation. This is a historical testnet
+record; it does not claim an active validator or public endpoint.
+
+## Technical contributions
+
+- Deployed and tested a Docker-based Sahara AI testnet node in April 2026.
+- Tested state-sync and block-sync recovery paths and documented the observed
+  limitations when no usable snapshot or state-sync path was available.
+- Published a reusable installation guide, official resource links, and a
+  snapshot-availability note in the POSTHUMAN public source-data repository.
+
+## Public documentation
+
+- [Installation guide](https://github.com/Validator-POSTHUMAN/posthuman-source-data/blob/main/sahara-testnet/installation-guide.md)
+- [Official resources and endpoints](https://github.com/Validator-POSTHUMAN/posthuman-source-data/blob/main/sahara-testnet/links.md)
+- [Snapshot and sync notes](https://github.com/Validator-POSTHUMAN/posthuman-source-data/blob/main/sahara-testnet/snapshots.md)
+
+## Official Sahara AI resources
+
+- Website: https://saharaai.com/
+- Documentation: https://docs.saharaai.com/
+- GitHub: https://github.com/SaharaLabsAI
+
+No upstream Sahara AI pull request, formal partnership, endorsement, or
+currently active POSTHUMAN service is claimed on this page.


### PR DESCRIPTION
Adds concise historical contribution records for Sahara AI and Pharos. Both pages link to the public operator guides and explicitly avoid active validator, endpoint, partnership, or upstream-PR claims.