### PR TITLE
docs: update Gnoland services for Sapphire

### DIFF
--- a/Gno-land.md
+++ b/Gno-land.md
@@ -10,12 +10,11 @@
   ### At the moment, we provide the following services for Gnoland:
 
 - **Install Guide**: [Link](https://nodes.posthuman.digital/chains/gno?tab=installation-guide)
-- **Topaz RPC**: https://rpc-gnoland.posthuman.digital
-- **Topaz snapshots**: https://snapshots-gnoland.posthuman.digital
+- **Sapphire RPC**: https://rpc-gnoland.posthuman.digital
+- **Sapphire snapshots**: https://snapshots-gnoland.posthuman.digital
+- **GNO·SCOPE Sapphire explorer**: https://gnoland.app/
 
-Topaz services are available at https://nodes.posthuman.digital/chains/gno
-
-gno.land will be added to block explorer - explorer.posthuman.digital
+Sapphire guides and public infrastructure are available at https://nodes.posthuman.digital/chains/gno
 
 Adena Wallet added to centrifuge.digital - will be added full functionality of gno.land to centrifuge
 
@@ -109,5 +108,4 @@ Also, plans for gno.land:
  We're about distribute part of 20% of our validator's income to our delegators [Details](https://posthuman.digital/phmn)
 
  ### ***[Feel free to learn more about our team](https://posthuman.digital/team)***
-
 


### PR DESCRIPTION
## Summary

- update POSTHUMAN's Gnoland contribution record from Topaz to Sapphire
- add the live GNO·SCOPE Sapphire explorer

## Verification

- linked RPC, snapshot service, nodes page, and explorer are live
- stale Topaz wording is removed from the Gnoland contribution page
